### PR TITLE
fix regex to match foreach with associative arrays

### DIFF
--- a/grammars/latte.cson
+++ b/grammars/latte.cson
@@ -37,12 +37,14 @@
       '1': 'name': 'support.class.macro.latte'
   }
   {
-    'match': '{(foreach) +(\\\$[a-zA-Z][\\\w()->]*) +(as) (\\\$[a-zA-Z]\\\w*)}'
+    'match': '{(foreach) +(\\\$[a-zA-Z][\\\w()->]*) +(as) (\\\$[a-zA-Z]\\\w*)(\\\s+=>\\\s+(\\\$[a-zA-Z]\\\w*))?}'
     'captures':
       '1': 'name': 'support.class.macro.latte'
       '2': 'name': 'variable.other.latte'
       '3': 'name': 'support.class.macro.latte'
       '4': 'name': 'variable.class.macro.latte'
+      '5': 'name': 'support.class.macro.latte'
+      '6': 'name': 'variable.class.macro.latte'
   }
   {
     'match': '{(/foreach)}'


### PR DESCRIPTION
The [regex for macro `foreach`](https://github.com/r-st/language-latte/blob/master/grammars/latte.cson#L40) only matches macros like `{foreach $items as $item}`, but misses the syntax for associative arrays, deconstructing into key and value, like `{foreach $items as $key => $value}`.

This PR fixes that, showing it like the next screenshot:

![captura de pantalla de 2017-05-28 15-19-28](https://cloud.githubusercontent.com/assets/10707639/26529062/2186e08c-43b9-11e7-944f-ae4fc0042a3f.png)
